### PR TITLE
Add starting state exit code option

### DIFF
--- a/check_supervisord.py
+++ b/check_supervisord.py
@@ -214,6 +214,18 @@ class CheckSupervisord(object):
             ),
         )
         parser.add_argument(
+            "--starting-state-exit-code",
+            action="store",
+            dest="starting_state_exit_code",
+            type=str,
+            choices=self.EXIT_CODES.keys(),
+            default=self.STATUS_WARNING,
+            metavar="STARTING_STATE_EXIT_CODE",
+            help="starting state exit code. {statuses}".format(
+                statuses=self.HELP_STATUSES
+            ),
+        )
+        parser.add_argument(
             "--network-errors-exit-code",
             action="store",
             dest="network_errors_exit_code",
@@ -255,6 +267,8 @@ class CheckSupervisord(object):
         options = parser.parse_args()
         # update stopped state value from command line argument
         self.STATE_TO_TEMPLATE[self.STATE_STOPPED] = options.stopped_state_exit_code
+        # update starting state value from command line argument
+        self.STATE_TO_TEMPLATE[self.STATE_STARTING] = options.starting_state_exit_code
 
         # check mandatory command line options supplied
         if not options.server:


### PR DESCRIPTION
<!--- nagios-check-supervisord -->
<!--- .github/PULL_REQUEST_TEMPLATE.md -->


<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds an option to set the Nagios plugin exit code when a Supervisor program is in `STARTING` state. 

The default exit state remains unchanged as `warning`.

<!--- Describe your changes in detail -->

## Related Issue

Fixes issue https://github.com/vint21h/nagios-check-supervisord/issues/9

## Motivation and Context

I believe there are legitimate use cases for accepting programs to be frequently in a starting state. See issue https://github.com/vint21h/nagios-check-supervisord/issues/9

## How Has This Been Tested?

I have tested the script manually against a real world Supervisor socket with starting and non-starting programs. I have also confirmed backwards compatibility with previous implementations of this plugin.
